### PR TITLE
fix: cli normal msg color(black) not showing in terminal

### DIFF
--- a/command.go
+++ b/command.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// handleInitCmd handles the `init` command for gospur CLI.
 func handleInitCmd(cmd *cobra.Command, args []string) {
 	// isEarlyStage depicts the CLI is still in early stages
 	// and we don't have enough options for user prompts.
@@ -49,25 +50,29 @@ func handleInitCmd(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	if err := util.CreateTargetDir(targetPath.FullPath, true); err != nil {
+	// Creating the target project directory.
+	// It'll check if the dir already exist and is empty or not (strict).
+	if err := util.CreateTargetDir(targetPath.Path, true); err != nil {
 		fmt.Println(config.ErrMsg(err))
 		return
 	}
 
+	// Creating the project files in the target directory.
+	// Passing the go mod path for resolving Go imports.
 	if err := util.CreateProject(targetPath.Path, map[string]string{"ModPath": goModPath}); err != nil {
 		fmt.Println(config.ErrMsg(err))
 		return
 	}
 
+	// Running `go mod init` with the specified name.
 	if err := util.RunGoModInit(targetPath.Path, goModPath); err != nil {
 		fmt.Println(config.ErrMsg(err))
 		return
 	}
 
-	fmt.Println(config.SuccessMsg("\nProject Created! 🎉"))
-	fmt.Println(config.NormalMsg(fmt.Sprintf(`
-Please Run:
-
+	fmt.Println(config.SuccessMsg("\nProject Created! 🎉\n"))
+	fmt.Println("Please Run:")
+	fmt.Println(config.FaintMsg(fmt.Sprintf(`
 cd %s
 go install github.com/bokwoon95/wgo@latest
 npm install

--- a/config/config.go
+++ b/config/config.go
@@ -5,7 +5,8 @@ import "github.com/manifoldco/promptui"
 var (
 	ErrMsg     = promptui.Styler(promptui.FGRed)
 	SuccessMsg = promptui.Styler(promptui.FGGreen)
-	NormalMsg  = promptui.Styler(promptui.FGBlack)
+	NormalMsg  = promptui.Styler(promptui.FGWhite)
+	FaintMsg   = promptui.Styler(promptui.FGFaint)
 )
 
 var (

--- a/util/template_util.go
+++ b/util/template_util.go
@@ -32,7 +32,7 @@ func CreateProject(targetDir string, data interface{}) error {
 		// actual `template` itself.
 		processedTmpl, err := parseTemplate(targetFilePath, templatePath, baseTmplFS)
 		if err != nil {
-			return fmt.Errorf("\nFailed to process templates (CLI_ERROR): %v", err)
+			return fmt.Errorf("Failed to process templates (CLI_ERROR): %v", err)
 		}
 
 		// Creating the file with the parsed template.
@@ -42,7 +42,7 @@ func CreateProject(targetDir string, data interface{}) error {
 			nil,
 		)
 		if err != nil {
-			return fmt.Errorf("\nFailed to create file -> '%s' due to %v", processedTmpl.targetFilePath, err)
+			return fmt.Errorf("Failed to create file -> '%s' due to %v", processedTmpl.targetFilePath, err)
 		}
 	}
 
@@ -60,7 +60,7 @@ func CreateProject(targetDir string, data interface{}) error {
 		// actual `template` itself.
 		processedTmpl, err := parseTemplate(targetFilePath, templatePath, apiTmplFS)
 		if err != nil {
-			return fmt.Errorf("\nFailed to process templates (CLI_ERROR): %v", err)
+			return fmt.Errorf("Failed to process templates (CLI_ERROR): %v", err)
 		}
 
 		// Creating the file with the parsed template.
@@ -70,7 +70,7 @@ func CreateProject(targetDir string, data interface{}) error {
 			data,
 		)
 		if err != nil {
-			return fmt.Errorf("\nFailed to create file -> '%s' due to %v", processedTmpl.targetFilePath, err)
+			return fmt.Errorf("Failed to create file -> '%s' due to %v", processedTmpl.targetFilePath, err)
 		}
 	}
 
@@ -92,13 +92,13 @@ func CreateProject(targetDir string, data interface{}) error {
 			pageTmplFS,
 		)
 		if err != nil {
-			return fmt.Errorf("\nFailed to create file -> '%s' due to %v", targetFilePath, err)
+			return fmt.Errorf("Failed to create file -> '%s' due to %v", targetFilePath, err)
 		}
 	}
 
 	// Create an example public asset
 	if err := createExamplePublicAsset(targetDir); err != nil {
-		return fmt.Errorf("\nFailed to create the public directory %v", err)
+		return fmt.Errorf("Failed to create the public directory %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
### Problem
CLI messages with the color "black" were not visible in certain terminals with dark backgrounds.

### Fix
Updated the terminal message color to "white".

### Impact
No breaking changes.

### Closes
Closes #1
