### PR TITLE
fix(config.go): home and error template file contents interchanged

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,8 +36,8 @@ var (
 	}
 
 	ProjectPageFiles = map[string]string{
-		"web/Home.html":  "page/error.html.echo.tmpl",
-		"web/Error.html": "page/home.html.echo.tmpl",
+		"web/Home.html":  "page/home.html.echo.tmpl",
+		"web/Error.html": "page/error.html.echo.tmpl",
 	}
 
 	ProjectAPIFiles = map[string]string{


### PR DESCRIPTION
### Problem
- Contents of `Home.html` and `Error.html` were interchanged.

### Fix
- Updated `ProjectPageFiles` config to fix the issue. 

### Impact
No breaking change, just file name issue fixed.