### PR TITLE
fix: makefile dev cmd won't reload browser when changes applied in any go file

### DIFF
--- a/template/base/makefile.tmpl
+++ b/template/base/makefile.tmpl
@@ -14,7 +14,7 @@ dev:
     -file=.html \
 	-file=.css \
 	-xdir=public \
-    ENVIRONMENT=DEVELOPMENT go build -tags 'dev' -o bin/build main.go \
+	go build -tags 'dev' -o bin/build main.go \
     :: ENVIRONMENT=DEVELOPMENT ./bin/build \
-    :: wgo -dir=web node ./esbuild.config.js \
-	:: wgo -dir=node_modules npx livereload -w 1000 web
+    :: wgo -xdir=bin -xdir=node_modules -xdir=public node ./esbuild.config.js \
+	:: wgo -dir=node_modules npx livereload public


### PR DESCRIPTION
### Problem
In dev mode, saving any go file doesn't reload the browser

### Fix
Updated makefile.tmpl with corrected dev cmd

### Impact
No breaking change.