### PR TITLE
feat(cli): add 'version' command + ci: configure workflows for testing and releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.23.x' ]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Display Go version
+        run: go version
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          # Only minor and patch can be bumped.
+          version: '~> v0'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Integration Test for GoSpur CLI
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.23.x' ]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Display Go version
+        run: go version
+
+      - name: Install Dependencies
+        run: go mod tidy
+      
+      - name: Run Tests
+        run: go test -v ./... --race

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 bin
 .env
 testcli
+dist
+tmp

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,44 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - binary: gopspur
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+      - 386
+    ldflags: |
+      -X main.version={{.Version}} 
+      -X main.commit={{.Commit}} 
+      -X main.date={{.Date}}
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        format: zip
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,9 +17,9 @@ builds:
       - arm64
       - 386
     ldflags: |
-      -X main.version={{.Version}} 
-      -X main.commit={{.Commit}} 
-      -X main.date={{.Date}}
+      -X github.com/nilotpaul/gospur/config.version={{.Version}}
+      -X github.com/nilotpaul/gospur/config.commit={{.Commit}} 
+      -X github.com/nilotpaul/gospur/config.date={{.Date}}
 
 archives:
   - format: tar.gz

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ BINARY = $(BUILD_DIR)/gospur
 init: build
 	@$(BINARY) init
 
+version: build	
+	@$(BINARY) version
+
 # Development Commands
 run: build
 	@$(BINARY)
@@ -17,3 +20,7 @@ test:
 
 test-race:
 	@go test -v ./... --race
+
+# Only for local testing
+release:
+	@goreleaser release --snapshot --clean

--- a/cli.go
+++ b/cli.go
@@ -24,6 +24,15 @@ var (
 		Args:  cobra.MaximumNArgs(1),
 		Run:   handleInitCmd,
 	}
+
+	// Project version command
+	// On run -> gospur version.
+	versionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Shows the current installed version",
+		Args:  cobra.NoArgs,
+		Run:   handleVersionCmd,
+	}
 )
 
 func Execute() error {
@@ -32,5 +41,8 @@ func Execute() error {
 }
 
 func init() {
-	rootCmd.AddCommand(initCmd)
+	rootCmd.AddCommand(
+		initCmd,
+		versionCmd,
+	)
 }

--- a/command.go
+++ b/command.go
@@ -58,3 +58,14 @@ func handleInitCmd(cmd *cobra.Command, args []string) {
 
 	util.PrintSuccessMsg(targetPath.Path)
 }
+
+// handleVersionCmd handles the `version` command for gospur CLI.
+func handleVersionCmd(cmd *cobra.Command, args []string) {
+	version, err := config.GetVersion()
+	if err != nil {
+		fmt.Println(config.ErrMsg(err))
+		return
+	}
+
+	fmt.Println(config.NormalMsg("version: " + version))
+}

--- a/config/setting.go
+++ b/config/setting.go
@@ -1,6 +1,10 @@
 package config
 
-import "github.com/manifoldco/promptui"
+import (
+	"fmt"
+
+	"github.com/manifoldco/promptui"
+)
 
 const Logo string = `
    _____       _____                  
@@ -14,3 +18,18 @@ const Logo string = `
 `
 
 var LogoColoured string = promptui.Styler(promptui.FGCyan, promptui.FGBold)(Logo)
+
+// GoSpur CLI version info
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+func GetVersion() (string, error) {
+	if version == "dev" {
+		return "", fmt.Errorf("No version information available")
+	}
+
+	return version, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,18 @@ module github.com/nilotpaul/gospur
 go 1.23.3
 
 require (
+	github.com/manifoldco/promptui v0.9.0
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
+	github.com/yosssi/gohtml v0.0.0-20201013000340-ee4748c638f4
 )
 
 require (
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/manifoldco/promptui v0.9.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/yosssi/gohtml v0.0.0-20201013000340-ee4748c638f4 // indirect
 	golang.org/x/net v0.31.0 // indirect
 	golang.org/x/sys v0.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
+github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -22,7 +24,6 @@ github.com/yosssi/gohtml v0.0.0-20201013000340-ee4748c638f4 h1:0sw0nJM544SpsihWx
 github.com/yosssi/gohtml v0.0.0-20201013000340-ee4748c638f4/go.mod h1:+ccdNT0xMY1dtc5XBxumbYfOUhmduiGudqaDgD2rVRE=
 golang.org/x/net v0.31.0 h1:68CPQngjLL0r2AlUKiSxtQFKvzRVbnzLwMUn5SzcLHo=
 golang.org/x/net v0.31.0/go.mod h1:P4fl1q7dY2hnZFxEk4pPSkDHF+QqjitcnDjUQyMM+pM=
-golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b h1:MQE+LT/ABUuuvEZ+YQAMSXindAdUh7slEmAkup74op4=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.27.0 h1:wBqf8DvsY9Y/2P8gAfPDEYNuS30J4lPHJxXSb/nJZ+s=
 golang.org/x/sys v0.27.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 )
 
 func main() {
-	// Starts the CLI
 	if err := Execute(); err != nil {
 		fmt.Println(config.ErrMsg("Go Spur exited"))
 		os.Exit(1)


### PR DESCRIPTION
### Feature

- Added a new version command to the CLI to display the current installed version.
- Configured GitHub Actions workflows to automate unit tests and GoReleaser releases on tag pushes.

### Impact

- Introduced a new feature (version command) in the CLI.
- Automated CI/CD workflows for testing and release management.

### Breaking Changes
- No breaking changes.