### PR TITLE
feat(cli): added flags for stack config, new option for choosing rendering strategy & opts display with help cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ run: build
 	@$(BINARY)
 
 build: 
-	@CGO_ENABLED=0 go build -ldflags="-s -w" -o $(BINARY) .
+	@go build -o $(BINARY) .
 	@GOOS=windows GOARCH=amd64 go build -o $(BINARY).exe . 
 
 test:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Read detailed usage and examples of every stack configured.
 - Chi
 
 **Styling**
-- Vanilla CSS  
+- Vanilla  
 - Tailwind
 
 **UI Library** 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,21 @@ or download prebuilt binary
 
 # Usage
 
-```
+## Create a new project
+```sh
 gospur init [project-name]
+```
+## Update the CLI
+```sh
+gospur update
+``` 
+
+Check more options by:
+```sh
+# help for cli
+gospur --help
+# help for each command
+gospur init --help
 ```
 
 # Docs

--- a/cli.go
+++ b/cli.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/nilotpaul/gospur/config"
+	"github.com/nilotpaul/gospur/util"
 	"github.com/spf13/cobra"
 )
 
@@ -50,6 +52,24 @@ func Execute() error {
 }
 
 func init() {
+	// Flags for init cmd.
+	initCmd.Flags().StringVar(
+		&stackConfig.WebFramework, "framework", "",
+		strings.Join(config.WebFrameworkOpts, ", "),
+	)
+	initCmd.Flags().StringVar(
+		&stackConfig.CssStrategy, "styling", "",
+		strings.Join(config.CssStrategyOpts, ", "),
+	)
+	initCmd.Flags().StringVar(
+		&stackConfig.UILibrary, "ui", "",
+		strings.Join(util.GetMapKeys(config.UILibraryOpts), ", "),
+	)
+	initCmd.Flags().StringSliceVar(
+		&stackConfig.ExtraOpts, "extra", []string{},
+		fmt.Sprintf("One or Many: %s", strings.Join(config.ExtraOpts, ", ")),
+	)
+
 	rootCmd.AddCommand(
 		initCmd,
 		updateCmd,

--- a/cli.go
+++ b/cli.go
@@ -65,6 +65,10 @@ func init() {
 		&stackConfig.UILibrary, "ui", "",
 		strings.Join(util.GetMapKeys(config.UILibraryOpts), ", "),
 	)
+	initCmd.Flags().StringVar(
+		&stackConfig.RenderingStrategy, "render", "",
+		strings.Join(config.RenderingStrategy, ", "),
+	)
 	initCmd.Flags().StringSliceVar(
 		&stackConfig.ExtraOpts, "extra", []string{},
 		fmt.Sprintf("One or Many: %s", strings.Join(config.ExtraOpts, ", ")),

--- a/command.go
+++ b/command.go
@@ -27,8 +27,8 @@ func handleInitCmd(cmd *cobra.Command, args []string) {
 		fmt.Println(config.ErrMsg(err))
 		return
 	}
-	cfg := *stackConfig
 
+	cfg := *stackConfig
 	// Validate the provided options.
 	if err := util.ValidateStackConfig(cfg); err != nil {
 		fmt.Println(config.ErrMsg(err))

--- a/command.go
+++ b/command.go
@@ -12,6 +12,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var stackConfig = &util.StackConfig{}
+
 // handleInitCmd handles the `init` command for gospur CLI.
 func handleInitCmd(cmd *cobra.Command, args []string) {
 	targetPath, err := util.GetProjectPath(args)
@@ -21,12 +23,17 @@ func handleInitCmd(cmd *cobra.Command, args []string) {
 	}
 
 	// Building the stack config by talking user prompts.
-	stackCfg, err := util.GetStackConfig()
-	if err != nil {
+	if err := util.GetStackConfig(stackConfig); err != nil {
 		fmt.Println(config.ErrMsg(err))
 		return
 	}
-	cfg := *stackCfg
+	cfg := *stackConfig
+
+	// Validate the provided options.
+	if err := util.ValidateStackConfig(cfg); err != nil {
+		fmt.Println(config.ErrMsg(err))
+		return
+	}
 
 	// Asking for the go mod path from user.
 	goModPath, err := util.GetGoModulePath()

--- a/config/config.go
+++ b/config/config.go
@@ -32,7 +32,7 @@ var (
 	}
 	CssStrategyOpts = []string{
 		"Tailwind",
-		"Vanilla CSS",
+		"Vanilla",
 	}
 	UILibraryOpts = map[string][]string{
 		"Preline": {"Tailwind"},

--- a/config/config.go
+++ b/config/config.go
@@ -30,11 +30,6 @@ var (
 		"Fiber",
 		"Chi",
 	}
-	ExtraOpts = []string{
-		"HTMX",
-		"Dockerfile",
-	}
-
 	CssStrategyOpts = []string{
 		"Tailwind",
 		"Vanilla CSS",
@@ -42,6 +37,15 @@ var (
 	UILibraryOpts = map[string][]string{
 		"Preline": {"Tailwind"},
 		"DaisyUI": {"Tailwind"},
+	}
+	RenderingStrategy = []string{
+		"Templates",
+	}
+
+	// Flags Only
+	ExtraOpts = []string{
+		"HTMX",
+		"Dockerfile",
 	}
 )
 

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	if err := Execute(); err != nil {
-		fmt.Println(config.ErrMsg("Go Spur exited"))
+		fmt.Println(config.ErrMsg("GoSpur exited"))
 		os.Exit(1)
 	}
 }

--- a/template/base/makefile.tmpl
+++ b/template/base/makefile.tmpl
@@ -1,27 +1,6 @@
 {{- if .IsLinux -}}
-start: 
-	@node ./esbuild.config.js
-	@go build -tags '!dev' -o bin/build
-	@ENVIRONMENT=PRODUCTION ./bin/build
-
-build:
-	@node ./esbuild.config.js
-	@go build -tags 'dev' -o bin/build
-
-dev:
-	@wgo \
-    -exit \
-    -file=.go \
-    -file=.html \
-	-file=.css \
-	-xdir=public \
-	go build -tags 'dev' -o bin/build . \
-    :: ENVIRONMENT=DEVELOPMENT ./bin/build \
-    :: wgo -xdir=bin -xdir=node_modules -xdir=public node ./esbuild.config.js \
-	:: wgo -dir=node_modules npx livereload -w 400 public
-{{- else -}}
 # As you're not using linux, please vist https://github.com/nilotpaul/gospur/blob/main/docs/development-usage.md
-
+{{- end -}}
 start: 
 	@node ./esbuild.config.js
 	@go build -tags '!dev' -o bin/build
@@ -41,5 +20,4 @@ dev:
 	go build -tags 'dev' -o bin/build . \
     :: ENVIRONMENT=DEVELOPMENT ./bin/build \
     :: wgo -xdir=bin -xdir=node_modules -xdir=public node ./esbuild.config.js \
-	:: wgo -dir=node_modules npx livereload -w 400 public
-{{- end -}}
+	:: wgo -dir=node_modules npx livereload -w 800 web

--- a/util/command_util.go
+++ b/util/command_util.go
@@ -72,8 +72,20 @@ func GetStackConfig(cfg *StackConfig) error {
 		}
 		cfg.WebFramework = framework
 	}
+	// Rendering Strategy Options
+	if len(cfg.RenderingStrategy) == 0 {
+		renderingStratPrompt := promptui.Select{
+			Label: "Choose a Rendering Strategy",
+			Items: config.RenderingStrategy,
+		}
+		_, opts, err := renderingStratPrompt.Run()
+		if err != nil {
+			return fmt.Errorf("failed to select Rendering Strategy")
+		}
+		cfg.RenderingStrategy = opts
+	}
 	// CSS Strategy
-	if len(cfg.CssStrategy) == 0 {
+	if len(cfg.CssStrategy) == 0 && cfg.RenderingStrategy == "Templates" {
 		extraPrompt := promptui.Select{
 			Label: "Choose a CSS Strategy",
 			Items: config.CssStrategyOpts,
@@ -85,7 +97,7 @@ func GetStackConfig(cfg *StackConfig) error {
 		cfg.CssStrategy = css
 	}
 	// UI Library Options
-	if len(cfg.UILibrary) == 0 {
+	if len(cfg.UILibrary) == 0 && cfg.RenderingStrategy == "Templates" {
 		// Filtering the opts for UI Libs based on the css strategy chosen.
 		filteredOpts := make([]string, 0)
 		for lib, deps := range config.UILibraryOpts {
@@ -112,18 +124,6 @@ func GetStackConfig(cfg *StackConfig) error {
 			}
 			cfg.UILibrary = uiLib
 		}
-	}
-	// Rendering Strategy Options
-	if len(cfg.RenderingStrategy) == 0 {
-		renderingStratPrompt := promptui.Select{
-			Label: "Choose a Rendering Strategy",
-			Items: config.RenderingStrategy,
-		}
-		_, opts, err := renderingStratPrompt.Run()
-		if err != nil {
-			return fmt.Errorf("failed to select Rendering Strategy")
-		}
-		cfg.RenderingStrategy = opts
 	}
 
 	return nil

--- a/util/command_util.go
+++ b/util/command_util.go
@@ -54,70 +54,74 @@ type GitHubReleaseResponse struct {
 
 // GetStackConfig will give a series of prompts
 // to the user to configure their project stack.
-func GetStackConfig() (*StackConfig, error) {
-	var cfg StackConfig
-
+func GetStackConfig(cfg *StackConfig) error {
 	// Framework options
-	frameworkPrompt := promptui.Select{
-		Label: "Choose a web framework",
-		Items: config.WebFrameworkOpts,
-	}
-	_, framework, err := frameworkPrompt.Run()
-	if err != nil {
-		return nil, fmt.Errorf("failed to select web framework")
-	}
-	cfg.WebFramework = framework
-
-	// CSS Strategy
-	extraPrompt := promptui.Select{
-		Label: "Choose a CSS Strategy",
-		Items: config.CssStrategyOpts,
-	}
-	_, css, err := extraPrompt.Run()
-	if err != nil {
-		return nil, fmt.Errorf("failed to select CSS Strategy")
-	}
-	cfg.CssStrategy = css
-
-	// UI Library Options
-	// Filtering the opts for UI Libs based on the css strategy chosen.
-	filteredOpts := make([]string, 0)
-	for lib, deps := range config.UILibraryOpts {
-		if len(deps) == 0 {
-			filteredOpts = append(filteredOpts, lib)
-			continue
+	if len(cfg.WebFramework) == 0 {
+		frameworkPrompt := promptui.Select{
+			Label: "Choose a web framework",
+			Items: config.WebFrameworkOpts,
 		}
-		if contains(deps, cfg.CssStrategy) {
-			filteredOpts = append(filteredOpts, lib)
-		}
-	}
-	// Only ask anything if we have a compatible UI Lib for
-	// the chosen CSS Strategy.
-	if len(filteredOpts) != 0 {
-		// Asking for UI Lib if we've any filtered opts.
-		uiLibPrompt := promptui.Select{
-			Label: "Choose a UI Library",
-			Items: filteredOpts,
-		}
-		_, uiLib, err := uiLibPrompt.Run()
+		_, framework, err := frameworkPrompt.Run()
 		if err != nil {
-			return nil, fmt.Errorf("failed to select UI Library")
+			return fmt.Errorf("failed to select web framework")
 		}
-		cfg.UILibrary = uiLib
+		cfg.WebFramework = framework
 	}
+	// CSS Strategy
+	if len(cfg.CssStrategy) == 0 {
+		extraPrompt := promptui.Select{
+			Label: "Choose a CSS Strategy",
+			Items: config.CssStrategyOpts,
+		}
+		_, css, err := extraPrompt.Run()
+		if err != nil {
+			return fmt.Errorf("failed to select CSS Strategy")
+		}
+		cfg.CssStrategy = css
+	}
+	// UI Library Options
+	if len(cfg.UILibrary) == 0 {
+		// Filtering the opts for UI Libs based on the css strategy chosen.
+		filteredOpts := make([]string, 0)
+		for lib, deps := range config.UILibraryOpts {
+			if len(deps) == 0 {
+				filteredOpts = append(filteredOpts, lib)
+				continue
+			}
+			if contains(deps, cfg.CssStrategy) {
+				filteredOpts = append(filteredOpts, lib)
+			}
+		}
 
+		// Only ask anything if we have a compatible UI Lib for
+		// the chosen CSS Strategy.
+		if len(filteredOpts) != 0 {
+			// Asking for UI Lib if we've any filtered opts.
+			uiLibPrompt := promptui.Select{
+				Label: "Choose a UI Library",
+				Items: filteredOpts,
+			}
+			_, uiLib, err := uiLibPrompt.Run()
+			if err != nil {
+				return fmt.Errorf("failed to select UI Library")
+			}
+			cfg.UILibrary = uiLib
+		}
+	}
 	// Extra Add-Ons
-	extraOptsPrompt := ui.MultiSelect{
-		Label: "Choose one or many extra options",
-		Items: config.ExtraOpts,
+	if len(cfg.ExtraOpts) == 0 {
+		extraOptsPrompt := ui.MultiSelect{
+			Label: "Choose one or many extra options",
+			Items: config.ExtraOpts,
+		}
+		opts, err := extraOptsPrompt.Run()
+		if err != nil {
+			return fmt.Errorf("failed to select extra options")
+		}
+		cfg.ExtraOpts = opts
 	}
-	opts, err := extraOptsPrompt.Run()
-	if err != nil {
-		return nil, fmt.Errorf("failed to select extra options")
-	}
-	cfg.ExtraOpts = opts
 
-	return &cfg, nil
+	return nil
 }
 
 // GetGoModulePath will give a input prompt to the user

--- a/util/command_util.go
+++ b/util/command_util.go
@@ -28,6 +28,11 @@ type StackConfig struct {
 	// UI Library is pre-made styled libs like Preline.
 	UILibrary string
 
+	// RenderingStrategy defines how HTML is rendered.
+	// Eg. templates, templ, seperate client.
+	RenderingStrategy string
+
+	// Flags Only
 	// Extras are extra add-ons like css lib, HTMX etc.
 	ExtraOpts []string
 }
@@ -108,17 +113,17 @@ func GetStackConfig(cfg *StackConfig) error {
 			cfg.UILibrary = uiLib
 		}
 	}
-	// Extra Add-Ons
-	if len(cfg.ExtraOpts) == 0 {
-		extraOptsPrompt := ui.MultiSelect{
-			Label: "Choose one or many extra options",
-			Items: config.ExtraOpts,
+	// Rendering Strategy Options
+	if len(cfg.RenderingStrategy) == 0 {
+		renderingStratPrompt := promptui.Select{
+			Label: "Choose a Rendering Strategy",
+			Items: config.RenderingStrategy,
 		}
-		opts, err := extraOptsPrompt.Run()
+		_, opts, err := renderingStratPrompt.Run()
 		if err != nil {
-			return fmt.Errorf("failed to select extra options")
+			return fmt.Errorf("failed to select Rendering Strategy")
 		}
-		cfg.ExtraOpts = opts
+		cfg.RenderingStrategy = opts
 	}
 
 	return nil

--- a/util/template_util.go
+++ b/util/template_util.go
@@ -316,7 +316,7 @@ func matchFrameworkOpt(v string) bool {
 
 func matchStylingOpt(v string) bool {
 	switch v {
-	case "Vanilla CSS":
+	case "Vanilla":
 		return true
 	case "Tailwind":
 		return true

--- a/util/template_util.go
+++ b/util/template_util.go
@@ -122,6 +122,31 @@ func CreateProject(targetDir string, cfg StackConfig, data interface{}) error {
 	return nil
 }
 
+func ValidateStackConfig(cfg StackConfig) error {
+	var errors []string
+
+	if !matchFrameworkOpt(cfg.WebFramework) {
+		errors = append(errors, "Invalid Web Framework")
+	}
+	if !matchStylingOpt(cfg.CssStrategy) {
+		errors = append(errors, "Invalid CSS Strategy")
+	}
+	if !matchUIOpt(cfg.UILibrary) {
+		errors = append(errors, "Invalid UI Library")
+	}
+
+	for _, opt := range cfg.ExtraOpts {
+		if !matchExtraOpt(opt) {
+			errors = append(errors, fmt.Sprintf("Invalid Extra: %s", opt))
+		}
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf("\n%s", strings.Join(errors, "\n"))
+	}
+	return nil
+}
+
 // parseTemplate takes `fullWritePath`, template path and template embed.
 //
 // `fullWritePath` -> has to be joined with the project or targetPath. (eg. gospur/config/env.go)
@@ -274,4 +299,56 @@ func skipProjectfiles(filePath string, cfg StackConfig) bool {
 	}
 
 	return false
+}
+
+func matchFrameworkOpt(v string) bool {
+	switch v {
+	case "Echo":
+		return true
+	case "Chi":
+		return true
+	case "Fiber":
+		return true
+	default:
+		return false
+	}
+}
+
+func matchStylingOpt(v string) bool {
+	switch v {
+	case "Vanilla CSS":
+		return true
+	case "Tailwind":
+		return true
+	default:
+		return false
+	}
+}
+
+func matchUIOpt(v string) bool {
+	switch v {
+	case "Preline":
+		return true
+	case "DaisyUI":
+		return true
+	// Can be empty if not chosen or not compatible
+	case "":
+		return true
+	default:
+		return false
+	}
+}
+
+func matchExtraOpt(v string) bool {
+	switch v {
+	case "HTMX":
+		return true
+	case "Dockerfile":
+		return true
+	// Can be empty if not chosen
+	case "":
+		return true
+	default:
+		return false
+	}
 }

--- a/util/template_util_test.go
+++ b/util/template_util_test.go
@@ -20,7 +20,7 @@ func TestSkipProjectfiles(t *testing.T) {
 	a.False(skip)
 
 	// With Vanilla CSS, tailwind.config.js is not needed.
-	mockStackCfg.CssStrategy = "Vanilla CSS"
+	mockStackCfg.CssStrategy = "Vanilla"
 	skip = skipProjectfiles("tailwind.config.js", mockStackCfg)
 	a.True(skip)
 }

--- a/util/util.go
+++ b/util/util.go
@@ -99,6 +99,15 @@ func FindMatchingBinary(names []string, os string, arch string) string {
 	return ""
 }
 
+func GetMapKeys[K comparable, V any](m map[K]V) []K {
+	keys := make([]K, 0)
+	for k := range m {
+		keys = append(keys, k)
+	}
+
+	return keys
+}
+
 func uncompress(src io.Reader, url string) (io.Reader, error) {
 	if strings.HasSuffix(url, ".zip") {
 		buf, err := io.ReadAll(src)


### PR DESCRIPTION
### Feature:
- Flags to choose stack options.
- Rendering Strategy which will include templates, seperate client, [templ](https://templ.guide) and more.
- Help Command now shows all available config options.

### Impact:
- Easier time configuring due to flags.
- Extra Options replaced with Rendering Strategy.
- Extra Options can now only be specified via flag -> `--extra Dockerfile`.
- Vanilla CSS option changed to Vanilla.
- Watch target for browser reload changed from `public` to `web` folder.

### Breaking Changes:
- Extra Options can now only be specified via flag -> `--extra Dockerfile`.
- No major breaking changes introduced.