### PR TITLE
fix: api routes returning fallback html in production (#28)

### DIFF
--- a/template/api/api.go.chi.tmpl
+++ b/template/api/api.go.chi.tmpl
@@ -78,6 +78,9 @@ func (api *APIServer) Start() error {
 	r := NewRouter(api.env)
 	r.RegisterRoutes(mux)
 
+	// Static routes
+	api.ServeStatic(mux)
+
 	log.Printf("Visit http://localhost%s", api.listenAddr)
 
 	return http.ListenAndServe(api.listenAddr, mux)
@@ -100,8 +103,6 @@ func logger(h http.Handler) http.Handler {
 func (api *APIServer) registerGlobalMiddlewares(mux *chi.Mux) {
 	mux.Use(logger) // Logger should come before Recoverer
 	mux.Use(middleware.Recoverer)
-
-	api.ServeStatic(mux)
 }
 {{- else if .Render.IsSeperate -}}
 package api
@@ -146,6 +147,9 @@ func (api *APIServer) Start() error {
 	// Routes
 	r := NewRouter(api.env)
 	r.RegisterRoutes(mux)
+	
+	// Static routes
+	api.ServeStatic(mux)
 
 	log.Printf("Visit http://localhost%s", api.listenAddr)
 
@@ -156,7 +160,5 @@ func (api *APIServer) Start() error {
 func (api *APIServer) registerGlobalMiddlewares(mux *chi.Mux) {
 	mux.Use(middleware.Logger) // Logger should come before Recoverer
 	mux.Use(middleware.Recoverer)
-
-	api.ServeStatic(mux)
 }
 {{- end -}}

--- a/template/api/api.go.echo.tmpl
+++ b/template/api/api.go.echo.tmpl
@@ -49,6 +49,9 @@ func (api *APIServer) Start() error {
 	r := NewRouter(api.env)
 	r.RegisterRoutes(e.Router())
 
+	// Static routes
+	api.ServeStatic(e)
+
 	log.Printf("Visit http://localhost%s", api.listenAddr)
 
 	return e.Start(api.listenAddr)
@@ -80,8 +83,6 @@ func (api *APIServer) registerGlobalMiddlewares(e *echo.Echo) {
 
 	e.HTTPErrorHandler = HTTPErrorHandler
 	e.Renderer = &Template{templates: api.LoadTemplates(e), env: api.env}
-
-	api.ServeStatic(e)
 }
 {{- else if .Render.IsSeperate -}}
 package api
@@ -126,6 +127,9 @@ func (api *APIServer) Start() error {
 	r := NewRouter(api.env)
 	r.RegisterRoutes(e.Router())
 
+	// Static routes
+	api.ServeStatic(e)
+
 	log.Printf("Visit http://localhost%s", api.listenAddr)
 
 	return e.Start(api.listenAddr)
@@ -139,7 +143,5 @@ func (api *APIServer) registerGlobalMiddlewares(e *echo.Echo) {
 	}))
 
 	e.HTTPErrorHandler = HTTPErrorHandler
-
-	api.ServeStatic(e)
 }
 {{- end -}}

--- a/template/api/api.go.fiber.tmpl
+++ b/template/api/api.go.fiber.tmpl
@@ -68,6 +68,9 @@ func (api *APIServer) Start() error {
 	r := NewRouter(api.env)
 	r.RegisterRoutes(app)
 
+	// Static routes
+	api.ServeStatic(app)
+
 	log.Printf("Visit http://localhost%s", api.listenAddr)
 
 	return app.Listen(api.listenAddr)
@@ -82,8 +85,6 @@ func (api *APIServer) registerGlobalMiddlewares(app *fiber.App) {
 			return strings.HasPrefix(c.Path(), "/public")
 		},
 	}))
-
-	api.ServeStatic(app)
 }
 {{- else if .Render.IsSeperate -}}
 package api
@@ -131,6 +132,9 @@ func (api *APIServer) Start() error {
 	r := NewRouter(api.env)
 	r.RegisterRoutes(app)
 
+	// Static routes
+	api.ServeStatic(app)
+
 	log.Printf("Visit http://localhost%s", api.listenAddr)
 
 	return app.Listen(api.listenAddr)
@@ -140,7 +144,5 @@ func (api *APIServer) Start() error {
 func (api *APIServer) registerGlobalMiddlewares(app *fiber.App) {
 	app.Use(recover.New())
 	app.Use(logger.New())
-
-	api.ServeStatic(app)
 }
 {{- end -}}


### PR DESCRIPTION
### Problem
- API routes don't work and always return fallback html in production #28 

### Fix
- Registered static routes after api routes

### Impact
- Fixed the following issue
- No breaking changes introduced